### PR TITLE
Add tests covering basic expressions truth-table evaluations

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -5,47 +5,44 @@
 
 (defpackage #:lisp-inference
   (:use #:cl #:cl-user)
-  (:export
-   :double-negation
-   :de-morgan
-   :modus-ponens
-   :modus-tollens
-   :syllogism-disjunctive
-   :addiction
-   :conjunction
-   :simplification-first
-   :simplification-second
-   :syllogism-hypothetical
-   :absorption
-   :tests
-   :propositionp
-   :operationp
-   :unary-operationp
-   :binary-operationp
-   :valid-operationp
-   :binary-operationp
-   :negationp
-   :conjunctionp
-   :disjunctionp
-   :implicationp
-   :biconditionalp
-   :prefix-to-infix
-   :print-truth-table
-   :truth
-   :truth-infix
-   :lookup-internal-operators
-   :intern-symbol
-   :main
-   :~
-   :^
-   :v
-   :=>
-   :<=>
-   :[+]
-   :make-conjunction
-   :make-negation
-   :make-disjunction
-   :make-implication
-   :make-biconditional
-   :*valid-operators*)
+  (:export #:double-negation ;; equivalences
+           #:de-morgan
+           #:modus-ponens    ;; inferences
+           #:modus-tollens
+           #:syllogism-disjunctive
+           #:addiction
+           #:conjunction
+           #:simplification-first
+           #:simplification-second
+           #:syllogism-hypothetical
+           #:absorption     ;; parser
+           #:propositionp
+           #:operationp
+           #:unary-operationp
+           #:binary-operationp
+           #:valid-operationp
+           #:binary-operationp
+           #:negationp
+           #:conjunctionp
+           #:disjunctionp
+           #:implicationp
+           #:biconditionalp
+           #:~            ;; operators
+           #:^
+           #:v
+           #:=>
+           #:<=>
+           #:[+]
+           #:make-conjunction
+           #:make-negation
+           #:make-disjunction
+           #:make-implication
+           #:make-biconditional
+           #:*valid-operators*
+           #:prefix-to-infix
+           #:print-truth-table ;; truth-table.lisp
+           #:eval-expression
+           #:truth
+           #:truth-infix
+           #:main)
   (:nicknames "INFERENCE"))

--- a/src/truth-table.lisp
+++ b/src/truth-table.lisp
@@ -134,11 +134,21 @@
 (defun princ-n (string n)
   "Just print the STRING by N times"
   (dotimes (_ n) (princ string)))
+
 (defun print-bar (spaces)
   (princ "+")
   (princ-n "-" (1- (reduce #'+ spaces)))
   (princ "+")
   (princ #\newline))
+
+(defun eval-expression (exp)
+  "Return the boolean values of EXP
+Ex.: (eval-expression (=> p q))
+'TFTT'
+"
+  (let* ((tt (prepare-table (eval-operations (lookup-internal-operators exp))))
+         (tt-size (length exp)))
+    (apply #'concatenate 'string (cdr (nth (1- tt-size) tt)))))
 
 (defun print-truth-table (exp)
   "Given a EXP with prefixed notation generate

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -3,26 +3,33 @@
 
 (plan nil)
 
-;; inference rule tests
+
 (diag "== Inference rules!")
+
 (is (modus-ponens '(^ (=> p q) p))
     'q
     "Inference: MODUS-PONENS")
+
 (is (modus-tollens '(^ (=> p q) (~ p)))
     '(~ q)
     "Inference: MODUS-TOLLENS")
+
 (is (syllogism-disjunctive '(^ (v p q) (~ p)))
     'q
     "Inference: SYLLOGISM-DISJUNCTIVE")
+
 (is (syllogism-hypothetical '(^ (=> x y) (=> y z)))
     '(=> X Z)
     "Inference: SYLLOGISM-HYPOTHETICAL")
+
 (is (addiction 'p 'q)
     '(v p q)
     "Inference: ADDICTION")
+
 (is (conjunction '(=> p q) 'p)
     '(^ (=> P Q) P)
     "Inference: CONJUNCTION")
+
 (is (absorption '(=> r (^ x y)))
     '(=> R (^ R (^ X Y)))
     "Inference: ABSORPTION")
@@ -33,8 +40,8 @@
     's
     "Inference: SIMPLIFICATION SECOND")
 
-(diag "== Equivalence rules!")
 
+(diag "== Equivalence rules!")
 
 (is (de-morgan '(^ p q))
     '(~ (v (~ p) (~ q)))

--- a/t/tests.lisp
+++ b/t/tests.lisp
@@ -54,4 +54,31 @@
     'p
     "Equivalence: DOUBLE-NEGATION 2")
 
+
+(diag "== Truth-table tests!")
+
+(is (eval-expression '(^ p q))
+    "TFFF"
+    "AND OPERATION: p ^ q")
+
+(is (eval-expression '(v p q))
+    "TTTF"
+    "OR OPERATION: p v q")
+
+(is (eval-expression '(=> p q))
+    "TFTT"
+    "CONDITIONAL OPERATION: p => q")
+
+(is (eval-expression '(<=> p q))
+    "TFFT"
+    "BICONDITIONAL OPERATION: p <=> q")
+
+(is (eval-expression '([+] p q))
+    "FTTF"
+    "XOR OPERATION: p [+] q")
+
+(is (eval-expression '(~ p))
+    "FT"
+    "NOT OPERATION: ~ p")
+
 (finalize)


### PR DESCRIPTION
Cases:

+ p => q
+ p <=> q
+ p ^ q
+ p v q
+ p [+] q
+ ~ p

I wrote a function to help me testing that.  The function name is
`eval-expression`, which returns a string with the signature of the
expected truth-table of the given propositional expression.

The exports of src/package.lisp was re-organized as well.