### PR TITLE
Simplification: Move package definition to t/test.lisp 

### DIFF
--- a/lisp-inference.asd
+++ b/lisp-inference.asd
@@ -28,7 +28,6 @@
   :serial t
   :pathname "t"
   :depends-on (:lisp-inference :prove)
-  :components ((:file "package")
-               (:file "tests"))
+  :components ((:file "test"))
   :perform (asdf:test-op :after (op c)
                          (funcall (intern #.(string :run) :prove) c)))

--- a/lisp-inference.asd
+++ b/lisp-inference.asd
@@ -3,11 +3,13 @@
 
 ;;;; lisp-inference.asd
 
+(defparameter lisp-inference-version "0.1.0")
+
 (asdf:defsystem #:lisp-inference
   :description "An Inference Engine using Propositional Calculus"
   :author "Manoel Vilela <manoel_vilela@engineer.com>"
   :license "BSD"
-  :version "0.1"
+  :version lisp-inference-version
   :serial t
   :pathname "src"
   :components ((:file "package")
@@ -24,7 +26,7 @@
   :description "Lisp Inference Test Suit"
   :author "Manoel Vilela <manoel_vilela@engineer.com>"
   :license "BSD"
-  :version "0.1"
+  :version lisp-inference-version
   :serial t
   :pathname "t"
   :depends-on (:lisp-inference :prove)

--- a/run-test.lisp
+++ b/run-test.lisp
@@ -1,5 +1,5 @@
 (ql:quickload '(:prove :lisp-inference/test) :silent t)
 (setf prove:*enable-colors* t)
-(if (prove:run "t/tests.lisp")
+(if (prove:run "t/test.lisp")
     (sb-ext:exit :code 0)
     (sb-ext:exit :code 1))

--- a/t/package.lisp
+++ b/t/package.lisp
@@ -1,4 +1,0 @@
-(defpackage #:lisp-inference/test
-  (:use #:cl
-        #:lisp-inference
-        #:prove))

--- a/t/test.lisp
+++ b/t/test.lisp
@@ -1,3 +1,9 @@
+(defpackage #:lisp-inference/test
+  (:use #:cl
+        #:lisp-inference
+        #:prove))
+
+
 (in-package :lisp-inference/test)
 
 


### PR DESCRIPTION
CHANGELOG:
+ t/tests.lisp was renamed to t/test.lisp
+ Unify lisp-inference-version in asdf definition