### PR TITLE
Add fix-quicklisp.lisp: local-projects setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.fasl
+system-index.txt

--- a/build.lisp
+++ b/build.lisp
@@ -1,3 +1,4 @@
+(load "fix-quicklisp")
 (ql:quickload :prove)
 (ql:quickload :lisp-inference)
 (in-package :lisp-inference)

--- a/fix-quicklisp.lisp
+++ b/fix-quicklisp.lisp
@@ -1,0 +1,3 @@
+(eval-when (:load-toplevel :execute)
+  (pushnew (truename (sb-unix:posix-getcwd/)) ql:*local-project-directories* )
+  (ql:register-local-projects))

--- a/run-test.lisp
+++ b/run-test.lisp
@@ -1,3 +1,4 @@
+(load "fix-quicklisp")
 (ql:quickload '(:prove :lisp-inference/test) :silent t)
 (setf prove:*enable-colors* t)
 (if (prove:run "t/test.lisp")


### PR DESCRIPTION
This allows the project be executed without worrying of this
being in ~/.quicklisp/local-projects/ or not.