### PR TITLE
fix: set cursor explicitly as text selection for share-url text box

### DIFF
--- a/web/webapp.lisp
+++ b/web/webapp.lisp
@@ -146,7 +146,7 @@ history.pushState(null, '', url);
         :onclick (js-share-button-function)))
      (:input :type "text"
       :id "share-url"
-      :style "display: none; width: 100%; margin-top: 10px;"
+      :style "cursor: text; display: none; width: 100%; margin-top: 10px;"
       :readonly "readonly")
      (:pre :style "font-size: 20px" (truth table))
      (:pre (format nil "Operators: ~a" inference:*valid-operators*)))


### PR DESCRIPTION
Originally reported by @rafaelcn

#  Before
<img width="1280" height="428" alt="image" src="https://github.com/user-attachments/assets/3b8ad1a8-fdb8-43eb-836e-dd299b8ec6a4" />


# After
<img width="1280" height="428" alt="image" src="https://github.com/user-attachments/assets/0f7fecf2-702f-491c-a957-8c274fc53ffd" />
