### PR TITLE
refactor: reduce logs verbosity

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ COPY *.lisp .
 RUN ros install ./lisp-inference.asd
 RUN ros run -s lisp-inference/web -q
 EXPOSE 40000
-ENTRYPOINT ["/root/.roswell/bin/inference-server"]
+ENTRYPOINT ["/app/roswell/inference-server.ros"]

--- a/lisp-inference.asd
+++ b/lisp-inference.asd
@@ -31,6 +31,7 @@
   :homepage "https://github.com/ryukinix/lisp-inference"
   :serial t
   :depends-on (:lisp-inference
+               :40ants-logging
                :40ants-routes ;; implicit dependency of reblocks
                :reblocks
                :reblocks-ui

--- a/roswell/inference-server.ros
+++ b/roswell/inference-server.ros
@@ -32,10 +32,10 @@ exec ros -Q -- $0 "$@"
   (unwind-protect
        (handler-case
            (progn
-             (format t "[+] Starting Lisp Inference server...~%")
-             (lisp-inference/web:start *port*)
-             (format t "[+] http://127.0.0.1:~a~%" *port*)
-             (format t "[+] Press C-c to kill Lisp Inference server...~%")
+             (lisp-inference/web:start :port *port* :debug nil)
+             (log:info "[+] Starting Lisp Inference server...~%")
+             (log:info "[+] http://127.0.0.1:~a~%" *port*)
+             (log:info "[+] Press C-c to kill Lisp Inference server...~%")
              (loop do (sleep 10)))
          (#+sbcl sb-sys:interactive-interrupt
           #+ccl  ccl:interrupt-signal-condition

--- a/web/webapp.lisp
+++ b/web/webapp.lisp
@@ -91,6 +91,7 @@ history.pushState(null, '', url);
 (defun truth-table (exp)
   (with-output-to-string (s)
     (let ((inference:*output-stream* s))
+      (log:info "expression: ~a" exp)
       (handler-case (inference:print-truth-table
                      (inference:parse-logic exp))
         (simple-error (c)
@@ -192,8 +193,10 @@ history.pushState(null, '', url);
                       *proposition*
                       prop))))
 
-(defun start (&optional (port *port*))
-  (reblocks/debug:on)
+(defun start (&key (port *port*) (debug t))
+  (if debug
+      (reblocks/debug:on)
+      (40ants-logging:setup-for-cli :level :info))
   (reblocks/server:stop)
   (reblocks/server:start :port port))
 


### PR DESCRIPTION
- log expressions used in the web server for curiosity.
- set log level to info instead debug
- use /app/roswell/inference-server.ros as entrypoint